### PR TITLE
Set the context to make easier to identify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
           working_directory: ~/my-app
           environment:
             MOCHA_FILE: junit/test-results.xml
+            KEY: "1234"
           command: |
             mkdir junit
             npm run test:ci

--- a/src/github/create_commit_status.js
+++ b/src/github/create_commit_status.js
@@ -3,7 +3,7 @@ const axios = require('axios')
 async function createCommitStatus ({ token, repoName, sha, state, description }) {
   const API_ROOT = process.env.API_ROOT || 'https://api.github.com'
   const url = `${API_ROOT}/repos/${repoName}/statuses/${sha}?access_token=${token}`
-  const status = { state, description }
+  const status = { state, description, context: 'CheckFixup' }
 
   const { data } = await axios.post(url, status)
 

--- a/src/hook/controller.test.js
+++ b/src/hook/controller.test.js
@@ -10,6 +10,7 @@ const { postHook } = require('./controller')
 
 describe('webhook controller', () => {
   beforeEach(async () => {
+    process.env.Key = '"test"'
     this.sandbox = sinon.sandbox.create()
 
     this.reqMock = {
@@ -70,7 +71,8 @@ describe('webhook controller', () => {
           .reply(200, commitsWithoutFixup)
           .post('/repos/ztolley/checkfixup/statuses/fe508425a4fd4327bdaef85846e9a06f22420895?access_token=443322', {
             state: 'success',
-            description: 'No fixups found'
+            description: 'No fixups found',
+            context: 'CheckFixup'
           })
           .reply(200)
 
@@ -97,7 +99,8 @@ describe('webhook controller', () => {
           .reply(200, commitsWithFixup)
           .post('/repos/ztolley/checkfixup/statuses/fe508425a4fd4327bdaef85846e9a06f22420895?access_token=443322', {
             state: 'failure',
-            description: 'Branch contains fixup!'
+            description: 'Branch contains fixup!',
+            context: 'CheckFixup'
           })
           .reply(200)
 


### PR DESCRIPTION
Without a context the github checks section in a pull request simply reads 'default'. This needs to indicate the name of the check that was done.