### PR TITLE
Add logging to slack

### DIFF
--- a/src/github/access_token_for_installation.js
+++ b/src/github/access_token_for_installation.js
@@ -18,8 +18,6 @@ async function accessTokenForInstallation (installationId) {
 
   const url = `${API_ROOT}/installations/${installationId}/access_tokens`
 
-  console.info('Getting token: ', url)
-
   const { data } = await axios({
     method: 'POST',
     url,

--- a/src/github/access_token_for_installation.js
+++ b/src/github/access_token_for_installation.js
@@ -16,9 +16,13 @@ async function accessTokenForInstallation (installationId) {
       expiresIn: '10m'
     })
 
+  const url = `${API_ROOT}/installations/${installationId}/access_tokens`
+
+  console.info('Getting token: ', url)
+
   const { data } = await axios({
     method: 'POST',
-    url: `${API_ROOT}/installations/${installationId}/access_tokens`,
+    url,
     headers: {
       Authorization: 'Bearer ' + token,
       Accept: CONTENT_TYPE

--- a/src/hook/controller.js
+++ b/src/hook/controller.js
@@ -7,6 +7,8 @@ const {
   createCommitStatus
 } = require('../github')
 
+const { log } = require('../logging')
+
 /* POST Github hook
  * Accepts a webhook call from Github details a Git Push.
  * Analyses the push and sets a status to indicate if the
@@ -16,11 +18,10 @@ const {
 */
 async function postHook (req, res, next) {
   try {
-    console.info('webhook called')
-
     const eventType = get(req, 'headers.x-github-event', 'n/a')
+
     if (eventType !== 'push') {
-      console.info('Invalid event, ignoring')
+      log({ text: `Invalid event, ignoring: ${eventType}` })
       return res.status(202).send('Invalid event, ignoring')
     }
 
@@ -31,16 +32,22 @@ async function postHook (req, res, next) {
     const installationId = get(pushData, 'installation.id')
 
     if (!headCommit) {
-      console.info('Ignoring event, no commits to analyse')
+      log({ text: 'Ignoring event, no commits to analyse' })
       return res.status(202).send('Ignoring event, no commits to analyse')
     }
 
     if (branch === defaultBranch) {
-      console.info('Ignoring event, default branch')
+      log({ text: 'Ignoring event, default branch' })
       return res.status(202).send('Ignoring event, default branch')
     }
 
-    console.info('processing')
+    log({ text: 'Processing hook',
+      fields: {
+        'Repository': repoName,
+        'Branch': branch
+      }
+    })
+
     const token = await accessTokenForInstallation(installationId)
     const hasFixup = await branchHasFixup({ token, repoName, branch, defaultBranch })
     const baseStatus = { token, repoName, sha: headCommit }
@@ -48,16 +55,21 @@ async function postHook (req, res, next) {
       ? assign({}, baseStatus, { state: 'failure', description: 'Branch contains fixup!' })
       : assign({}, baseStatus, { state: 'success', description: 'No fixups found' })
 
-    console.info('Setting status: ', status)
+    log({
+      text: status.description,
+      status: status.state,
+      fields: {
+        'Repository': repoName,
+        'Branch': branch
+      }
+    })
 
     await createCommitStatus(status)
   } catch (error) {
-    console.error(error.message)
-    console.log(error)
+    await log({ error })
     return res.status(500).send(error.message)
   }
 
-  console.info('Webhook complete')
   res.status(200).send('Webhook handled successfully')
 }
 

--- a/src/hook/controller.js
+++ b/src/hook/controller.js
@@ -53,6 +53,7 @@ async function postHook (req, res, next) {
     await createCommitStatus(status)
   } catch (error) {
     console.error(error.message)
+    console.log(error)
     return res.status(500).send(error.message)
   }
 

--- a/src/logging/index.js
+++ b/src/logging/index.js
@@ -1,0 +1,57 @@
+const axios = require('axios')
+const { pick } = require('lodash')
+
+function transposeFields (fields) {
+  const fieldKeys = Object.keys(fields)
+
+  return fieldKeys.map((key) => {
+    return {
+      title: key,
+      value: fields[key],
+      short: true
+    }
+  })
+}
+
+/**
+ *
+ * @param {*} params
+ * @param {string} params.status  SUCCESS, FAILURE, ERROR
+ */
+function log ({ text = '', status, fields = {}, slack = true, error }) {
+  const colours = {
+    error: '#D00000',
+    falure: '#ff9000',
+    success: '#36a64f'
+  }
+
+  const payload = !error ? {
+    attachments: [{
+      color: colours[status] || '#000000',
+      title: `Checkfixup ${process.env.SLACK_ENV}`,
+      text,
+      fields: transposeFields(fields)
+    }]
+  } : {
+    attachments: [{
+      color: colours['error'],
+      title: `Checkfixup ${process.env.SLACK_ENV}`,
+      fallback: error.message,
+      pretext: error.message,
+      text: JSON.stringify(pick(error, ['config', 'stack', 'message']), null, '\t'),
+      fields: transposeFields(fields)
+    }]
+  }
+
+  if (slack && process.env.SLACK_ID) {
+    const url = `https://hooks.slack.com/services/${process.env.SLACK_ID}`
+    axios.post(url, payload)
+  }
+}
+
+module.exports = {
+  log,
+  ERROR: 'error',
+  SUCCESS: 'success',
+  FAILURE: 'failure'
+}


### PR DESCRIPTION
Creates a new logger that supports logging to the console and slack.

This allows a slack channel to receive the message so can see at a glance when the service is used and also outputs an error into the channel to allow instant debugging without having to access the heroku instance.